### PR TITLE
Change HLS segment extension to html

### DIFF
--- a/files/tasks.py
+++ b/files/tasks.py
@@ -32,6 +32,7 @@ from .helpers import (
     produce_ffmpeg_commands,
     produce_friendly_token,
     rm_file,
+    convert_hls_segment_extension,
     run_command,
     trim_video_method,
 )
@@ -544,6 +545,8 @@ def create_hls(friendly_token):
                 # because create_hls was running multiple times
                 pass
             output_dir = existing_output_dir
+
+        convert_hls_segment_extension(output_dir, ".ts", ".html")
         pp = os.path.join(output_dir, "master.m3u8")
         if os.path.exists(pp):
             if media.hls_file != pp:


### PR DESCRIPTION
## Summary
- support changing HLS segment extensions
- rename generated `.ts` segments to `.html` after running `mp4hls`

## Testing
- `pre-commit` *(fails: command not found)*
- `flake8 files/helpers.py files/tasks.py` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_684f89688888832d876c4afa43c3f172