### PR TITLE
Add S3 upload helper

### DIFF
--- a/files/tasks.py
+++ b/files/tasks.py
@@ -547,6 +547,11 @@ def create_hls(friendly_token):
             output_dir = existing_output_dir
 
         convert_hls_segment_extension(output_dir, ".ts", ".html")
+
+        bucket = os.environ.get("AWS_S3_BUCKET")
+        prefix = os.environ.get("AWS_S3_PREFIX", "")
+        if bucket:
+            upload_and_cleanup(output_dir, bucket, prefix)
         pp = os.path.join(output_dir, "master.m3u8")
         if os.path.exists(pp):
             if media.hls_file != pp:


### PR DESCRIPTION
## Summary
- add boto3 import in `helpers.py`
- implement `upload_and_cleanup` utility to push HTML & m3u8 assets to S3
- automatically run upload helper after HLS conversion if `AWS_S3_BUCKET` is set

## Testing
- `pytest -q` *(fails: ImportError during Django test collection)*

------
https://chatgpt.com/codex/tasks/task_e_684f921fae9c832dad6037944b215e20